### PR TITLE
Eslint config fix

### DIFF
--- a/packages/mudita-eslint-config/.eslintrc.js
+++ b/packages/mudita-eslint-config/.eslintrc.js
@@ -4,7 +4,6 @@ module.exports = {
   },
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "prettier",
     "prettier/@typescript-eslint",
@@ -13,6 +12,7 @@ module.exports = {
     "plugin:testing-library/recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
+    "plugin:@typescript-eslint/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {

--- a/packages/mudita-eslint-config/package-lock.json
+++ b/packages/mudita-eslint-config/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appnroll/eslint-config",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/mudita-eslint-config/package.json
+++ b/packages/mudita-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mudita/eslint-config",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
When implementing the `@mudita/eslint-config` into https://github.com/mudita/ipfs-electron-poc I had an issue with `no-unused-vars` [rule](https://eslint.org/docs/rules/no-unused-vars) that were reporting exported interfaces as unused vars which is false of course (https://github.com/typescript-eslint/typescript-eslint/issues/363). However I found [a suggestion](https://stackoverflow.com/questions/57802057/eslint-configuring-no-unused-vars-for-typescript#comment116747895_58513127) that seems to work - placing `"plugin:@typescript-eslint/recommended"` on the last position of `extends` array.